### PR TITLE
修复双击查询单词时定位不准确的问题

### DIFF
--- a/js/shanbay.js
+++ b/js/shanbay.js
@@ -139,9 +139,8 @@ function getSelectionOffset(callback) {
         var range = window.getSelection().getRangeAt(0);
         var dummy = document.createElement('span');
         range.insertNode(dummy);
-        left = getLeft(dummy) - 50 - dummy.offsetLeft + $(dummy).position().left;
-        top = getTop(dummy) + 25 - dummy.offsetTop + $(dummy).position().top;
-        ;
+        left = $(dummy).offset().left - 50 - dummy.offsetLeft + $(dummy).position().left;
+        top = $(dummy).offset().top + 25 - dummy.offsetTop + $(dummy).position().top;
         dummy.remove();
         window.getSelection().addRange(range);
     }


### PR DESCRIPTION
当查询的单词处于一个页面滚动区域位置时（即单词在`overflow: auto`里面区域），双击查询单词时，原本的`getTop`计算会有缺陷。直接改为使用`jQuery`的`offset`函数。